### PR TITLE
Add link to view image on oam browser

### DIFF
--- a/app/assets/scripts/views/status.js
+++ b/app/assets/scripts/views/status.js
@@ -4,6 +4,7 @@ var Router = require('react-router');
 var RouteHandler = Router.RouteHandler;
 var moment = require('moment');
 var titlecase = require('titlecase');
+var turfCentroid = require('turf-centroid');
 
 var util = require('util');
 var url = require('url');
@@ -96,8 +97,23 @@ var App = module.exports = React.createClass({
     var status;
     var messages = image.messages.map(function (msg) { return <li>{msg}</li> });
     if (image.status === 'finished') {
+
+      var bb = image.metadata.bbox
+      var f = {
+        type: 'Feature',
+        geometry: {
+          type: "Polygon",
+          coordinates: [[
+            [bb[1], bb[0]],
+            [bb[3], bb[2]]
+          ]]
+        }
+      }
+      var coords = turfCentroid(f).geometry.coordinates;
+      var url = 'http://hotosm.github.io/oam-browser/#/' + coords[0] + ',' + coords[1] + ',12';
+
       status = 'status-success'
-      messages.unshift(<li><a href="#" title="View image on OpenAerialMap" className="bttn-view-image">View image</a></li>)
+      messages.unshift(<li><a href={url} title="View image on OpenAerialMap" className="bttn-view-image">View image</a></li>)
     } else if (image.status === 'processing') {
       status = 'status-processing'
       messages.unshift(<li>Upload in progress.</li>)

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "react-validation-mixin": "^4.2.0",
     "react-widgets": "^2.8.0",
     "reflux": "^0.2.12",
-    "titlecase": "^1.0.2"
+    "titlecase": "^1.0.2",
+    "turf-centroid": "^1.1.2"
   }
 }


### PR DESCRIPTION
The "view image" button opens the oam-browser in the area where the image is.

Is very tricky to select the image so we're just directing the user to the correct place. The user will still have to click on the square to get the image. 

The idea is to improve on this when we start experimenting with vector tiles.
