### PR TITLE
Add error message for invalid token

### DIFF
--- a/app/assets/scripts/views/home.js
+++ b/app/assets/scripts/views/home.js
@@ -221,13 +221,22 @@ var Home = module.exports = React.createClass({
             this.resetForm();
           } else {
 
-            AppActions.showNotification('alert', (
-              <span>
-                There was a problem with the request.<br/>
-                The OAM Upload server responded with: {resp.statusCode}<br/>
-                {'' + body}
-              </span>
-            ));
+            var message = null;
+            if (resp.statusCode == 401) {
+              message = (
+                <span>The provided token is not valid.</span>
+              );
+            }
+            else {
+              message = (
+                <span>
+                  There was a problem with the request.
+                </span>
+              );
+              console.log(body);
+            }
+
+            AppActions.showNotification('alert', message);
 
           }
         }.bind(this));


### PR DESCRIPTION
The invalid token is handled.

@anandthakker please check if there's any other specific error that we want to handle in a more user friendly way.
The default is `There was a problem with the request.`
